### PR TITLE
#44 fixed alphabet buttons not reseting

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -398,6 +398,7 @@ async function chooseServer(number, row) {
     $("#episodesTable tbody").empty();
     $("#audioTable tbody").empty();
     $("#subtitleTable tbody").empty();
+    $('#alphabetGroup').children().removeClass("btn-dark").addClass("btn-outline-dark").prop("disabled", true);
 
     $(row).siblings().removeClass("table-active");
     $(row).addClass("table-active");


### PR DESCRIPTION
Whenever the server is changed the alphabet buttons on the series page will be reset.
fixes #44 