### PR TITLE
[QOL] Make confirmation episode list alphabetical

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1085,12 +1085,10 @@ async function setAudioStream(partsId, streamId, row) {
                     "X-Plex-Token": plexToken,
                     "Accept": "application/json"
                 }
-            }).then((result) => {
-                $('#progressModal #modalBodyText').append(data.messageAppend);
-                $(row).siblings().removeClass("table-active");
-                $(row).addClass("table-active");
+            }).then((_result) => {
                 handleProgress();
-            }).catch((e) => console.log(e));
+                return data;
+            });
         }
 
         for (let k = 0; k < promiseConstructors.length; k++) {
@@ -1107,6 +1105,15 @@ async function setAudioStream(partsId, streamId, row) {
 
         try {
             Promise.allSettled(matchPromises).then(() => {
+                matchPromises.forEach(async (matchPromise) => {
+                    await matchPromise.then((data) => {
+                        $('#progressModal #modalBodyText').append(data.messageAppend);
+                        $(row).siblings().removeClass("table-active");
+                        $(row).addClass("table-active");
+                    }).catch((e) => console.log(e));
+                })
+            })
+            .then(() => {
                 $('#modalBodyText .alert').removeClass("alert-warning").addClass("alert-success");
                 $("#modalBodyText #modalTitleText").text("Processing Complete! You can now close this popup.");
                 $('#modalBodyText #progressBarContainer').hide();
@@ -1394,11 +1401,9 @@ async function setSubtitleStream(partsId, streamId, row) {
                     "X-Plex-Token": plexToken,
                     "Accept": "application/json"
                 }
-            }).then((result) => {
-                $('#progressModal #modalBodyText').append(data.messageAppend);
-                $(row).siblings().removeClass("table-active");
-                $(row).addClass("table-active");
+            }).then((_result) => {
                 handleProgress();
+                return data;
             }).catch((e) => console.log(e));
         } 
 
@@ -1416,6 +1421,15 @@ async function setSubtitleStream(partsId, streamId, row) {
 
         try {
             Promise.allSettled(matchPromises).then(() => {
+                matchPromises.forEach(async (matchPromise) => {
+                    await matchPromise.then((data) => {
+                        $('#progressModal #modalBodyText').append(data.messageAppend);
+                        $(row).siblings().removeClass("table-active");
+                        $(row).addClass("table-active");
+                    }).catch((e) => console.log(e));
+                })
+            })
+            .then(() => {
                 $('#modalBodyText .alert').removeClass("alert-warning").addClass("alert-success");
                 $("#modalBodyText #modalTitleText").text("Processing Complete! You can now close this popup.");
                 $('#modalBodyText #progressBarContainer').hide();


### PR DESCRIPTION
Slightly refactored the way the list of episodes was added to the DOM such that it's possible to list them alphabetically rather than in the order of their Promise resolution.

**Current behavior** (_close to sorted, but not quite_)

![Current Behavior](https://github.com/cglatot/pasta/assets/7389238/f22d89a8-f5d4-45dd-b655-aa205225763a)

**Sorted**

![Presented list in sorted order](https://github.com/cglatot/pasta/assets/7389238/2705de33-15d4-4f96-9e34-6d929c1721df)

