### PR TITLE
Add option to set track to entire library

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -240,6 +240,14 @@ label, p {
     cursor: default;
 }
 
+#movieOrLibraryBtns label, #pinOrAuthBtns label {
+    cursor: pointer;
+}
+
+#movieOrLibraryBtns label.active, #pinOrAuthBtns label.active {
+    cursor: default;
+}
+
 #alphabetGroup {
     border-radius: 0.25rem;
     overflow: hidden;
@@ -315,6 +323,34 @@ label, p {
 }
 
 #episodeOrSeriesBtns .btn-secondary.active:hover, #pinOrAuthBtns .btn-secondary.active:hover {
+    color: #fff;
+    background-color: #d4860b;
+    border-color: #c87f0a;
+}
+
+#movieOrLibraryBtns .btn-secondary, #pinOrAuthBtns .btn-secondary {
+    color: rgb(240,240,240);
+    background-color: #444;
+    border-color: #444;
+}
+
+#movieOrLibraryBtns .btn-secondary:hover, #pinOrAuthBtns .btn-secondary:hover {
+    color: rgb(240,240,240);
+    background-color: #333;
+    border-color: #2c2c2c;
+}
+
+#movieOrLibraryBtns .btn-secondary.active, #pinOrAuthBtns .btn-secondary.active {
+    color: #fff;
+    background-color: #F39C12;
+    border-color: #F39C12;
+}
+
+#movieOrLibraryBtns .btn-secondary.active.focus, #pinOrAuthBtns .btn-secondary.active.focus {
+    box-shadow: 0 0 0 0.2rem rgba(243,156,18,.25);
+}
+
+#movieOrLibraryBtns .btn-secondary.active:hover, #pinOrAuthBtns .btn-secondary.active:hover {
     color: #fff;
     background-color: #d4860b;
     border-color: #c87f0a;

--- a/index.html
+++ b/index.html
@@ -470,8 +470,8 @@
                         </div>
                         <!-- / EPISODES TABLE -->
 
-                        <!-- SWITCH TOGGLE -->
-                        <div id="switchToggleContainer" class="row mt-4">
+                        <!-- TV SWITCH TOGGLE -->
+                        <div id="tvSwitchToggleContainer" class="row mt-4">
                             <div class="col text-center">
                                 <div id="episodeOrSeriesBtns" class="btn-group btn-group-toggle" data-toggle="buttons">
                                     <label class="btn btn-secondary active">
@@ -486,10 +486,31 @@
                                         <input type="radio" name="episodeOrSeries" id="entireSeries" autocomplete="off">
                                         Entire Series
                                     </label>
+                                    <label class="btn btn-secondary">
+                                        <input type="radio" name="episodeOrSeries" id="entireLibrary" autocomplete="off">
+                                        Entire Library
+                                    </label>
                                 </div>
                             </div>
                         </div>
-                        <!-- / SWITCH TOGGLE -->
+                        <!-- / TV SWITCH TOGGLE -->
+
+                        <!-- Movie SWITCH TOGGLE -->
+                        <div id="movieSwitchToggleContainer" class="row mt-4">
+                            <div class="col text-center">
+                                <div id="movieOrLibraryBtns" class="btn-group btn-group-toggle" data-toggle="buttons">
+                                    <label class="btn btn-secondary active">
+                                        <input type="radio" name="movieOrLibrary" id="singleMovie" autocomplete="off">
+                                        Single Movie
+                                    </label>
+                                    <label class="btn btn-secondary">
+                                        <input type="radio" name="movieOrLibrary" id="movieEntireLibrary" autocomplete="off">
+                                        Entire Library
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- / Movie SWITCH TOGGLE -->
 
                         <!-- MOVIE NAME -->
                         <div id="movieNamePlaceholder" class="row mt-4">

--- a/js/main.js
+++ b/js/main.js
@@ -1202,9 +1202,6 @@ async function setSubtitleStream(partsId, streamId, row) {
     let currentProgress = 0;
     let maxProgress = 0;
 
-    console.log(libraryType);
-    console.log(singleEpisode);
-
     if ((libraryType == "shows" && singleEpisode) || (libraryType == "movie" && singleMovie)) {
         console.log("singleEpisode");
         $.ajax({
@@ -1328,8 +1325,6 @@ async function setSubtitleStream(partsId, streamId, row) {
                 }
             }
         }
-
-        console.log(episodeList);
 
         // Set the progress bar to have a certain length
         maxProgress = episodeList.length;


### PR DESCRIPTION
Fixes #35 

Adds an option for movies and TV Shows to set the track across the entire library. The method used to set the track is the same that is used for Single Season and Entire Series.

I also added a filter to only allow you to pick a TV Show or Movie Library in the library select panel. This removes music libraries from showing.