### PR TITLE
Add action for building Docker image on release creation

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,38 @@
+name: Build and Push Docker Image
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Log in to Docker Hub
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Build the Docker image with both the tag and latest
+      - name: Build Docker Image
+        run: |
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/pasta:${{ github.event.release.tag_name }} .
+          docker tag ${{ secrets.DOCKER_USERNAME }}/pasta:${{ github.event.release.tag_name }} ${{ secrets.DOCKER_USERNAME }}/pasta:latest
+
+      # Push the Docker image with the release tag
+      - name: Push Docker Image with Release Tag
+        run: |
+          docker push ${{ secrets.DOCKER_USERNAME }}/pasta:${{ github.event.release.tag_name }}
+
+      # Push the Docker image as latest
+      - name: Push Docker Image as Latest
+        run: |
+          docker push ${{ secrets.DOCKER_USERNAME }}/pasta:latest


### PR DESCRIPTION
Fixes #76  

I decided to make it build on a release creation instead of on pushes to the master branch; this will make it easier to control when it builds.

You will just need to create the following secrets for it to work:
- DOCKER_USERNAME
- DOCKER_PASSWORD