### PR TITLE
fix: remove early head closing tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 
-<head></head>
+<head>
     <title>PASTA | Audio & Subtitle Track Changer for Plex</title>
 
     <!-- Required meta tags -->


### PR DESCRIPTION
closes: #88 

the head tag is closed early breaking the head element, this removes the early closing tag

Before:
<img width="897" height="896" alt="image" src="https://github.com/user-attachments/assets/0f9b72a6-29e2-4706-a81e-ab7893101aee" />

After: 
<img width="880" height="892" alt="image" src="https://github.com/user-attachments/assets/d15027d3-2d88-4dcc-8d4e-b0d20dd4839f" />