### PR TITLE
updated CORS fixes

### DIFF
--- a/src/components/ServerSelection.tsx
+++ b/src/components/ServerSelection.tsx
@@ -72,7 +72,7 @@ export const ServerSelection: React.FC<Props> = ({ onConnect }) => {
                             onChange={handleCheckboxChange}
                         />
                         <label className="form-check-label" htmlFor="useLocalAddress">
-                            Use Local Address
+                            Prefer Local Address
                         </label>
                     </div>
                     {error && <div className="text-danger mt-2">{error}</div>}

--- a/src/hooks/usePlexServer.ts
+++ b/src/hooks/usePlexServer.ts
@@ -22,21 +22,26 @@ export const usePlexServer = () => {
         setConnecting(true);
         setConnectionError(null);
 
-        // Filter connections based on preference and protocol
-        const connections = server.connections.filter(c => {
+        // Filter connections based on protocol, then prioritize based on preference
+        let connections = server.connections.filter(c => {
             // Protocol check (HTTPS vs HTTP)
             if (window.location.protocol === 'https:' && c.protocol !== 'https') return false;
+            return true;
+        });
 
-            // Local address check
+        // Sort based on preference
+        connections.sort((a, b) => {
             if (useLocalAddress) {
-                return c.local === true;
+                // Prefer local: true < false (sort a before b if a is local)
+                return (a.local === b.local) ? 0 : (a.local ? -1 : 1);
             } else {
-                return c.local === false;
+                // Prefer remote: false < true (sort a before b if a is remote)
+                return (a.local === b.local) ? 0 : (!a.local ? -1 : 1);
             }
         });
 
         if (connections.length === 0) {
-            setConnectionError(`No ${useLocalAddress ? 'local' : 'remote'} connections found for this server.`);
+            setConnectionError(`No secure connections found for this server. enable 'Secure connections' in your Plex Media Server settings.`);
             setConnecting(false);
             return false;
         }

--- a/src/services/plex.ts
+++ b/src/services/plex.ts
@@ -15,9 +15,15 @@ export const PLEX_HEADERS = {
 const DEFAULT_TIMEOUT = 20000; // 20 seconds
 
 // Headers for direct Plex Media Server connections (minimal to avoid CORS issues)
-export const getPmsHeaders = (clientIdentifier: string, token: string) => {
+export const getPmsHeaders = () => {
     return {
         'Accept': 'application/json',
+    };
+};
+
+// Params for direct Plex Media Server connections (auth in query params avoids CORS preflight issues)
+export const getPmsParams = (clientIdentifier: string, token: string) => {
+    return {
         'X-Plex-Client-Identifier': clientIdentifier,
         'X-Plex-Token': token,
     };
@@ -90,7 +96,8 @@ export const checkServerIdentity = async (
     signal?: AbortSignal
 ) => {
     const response = await axios.get(`${serverUrl}/identity`, {
-        headers: getPmsHeaders(clientIdentifier, token),
+        params: getPmsParams(clientIdentifier, token),
+        headers: getPmsHeaders(),
         timeout: 5000, // Keep 5 second timeout for identity check as it needs to be fast
         signal, // Allow request cancellation
     });
@@ -99,7 +106,8 @@ export const checkServerIdentity = async (
 
 export const getLibraries = async (serverUrl: string, clientIdentifier: string, token: string) => {
     const response = await axios.get<PlexMediaContainer<PlexLibrary>>(`${serverUrl}/library/sections`, {
-        headers: getPmsHeaders(clientIdentifier, token),
+        params: getPmsParams(clientIdentifier, token),
+        headers: getPmsHeaders(),
         timeout: DEFAULT_TIMEOUT,
     });
     return response.data.MediaContainer.Directory || [];
@@ -113,8 +121,11 @@ export const getLibraryItems = async (
     params?: Record<string, string | number>
 ) => {
     const response = await axios.get<PlexMediaContainer<PlexMetadata>>(`${serverUrl}/library/sections/${libraryId}/all`, {
-        params,
-        headers: getPmsHeaders(clientIdentifier, token),
+        params: {
+            ...params,
+            ...getPmsParams(clientIdentifier, token),
+        },
+        headers: getPmsHeaders(),
         timeout: DEFAULT_TIMEOUT,
     });
     return response.data.MediaContainer.Metadata || [];
@@ -127,7 +138,8 @@ export const getMetadataChildren = async (
     token: string
 ) => {
     const response = await axios.get<PlexMediaContainer<PlexMetadata>>(`${serverUrl}/library/metadata/${ratingKey}/children`, {
-        headers: getPmsHeaders(clientIdentifier, token),
+        params: getPmsParams(clientIdentifier, token),
+        headers: getPmsHeaders(),
         timeout: DEFAULT_TIMEOUT,
     });
     return response.data.MediaContainer.Metadata || [];
@@ -140,7 +152,8 @@ export const getMetadata = async (
     token: string
 ) => {
     const response = await axios.get<PlexMediaContainer<PlexMetadata>>(`${serverUrl}/library/metadata/${ratingKey}`, {
-        headers: getPmsHeaders(clientIdentifier, token),
+        params: getPmsParams(clientIdentifier, token),
+        headers: getPmsHeaders(),
         timeout: DEFAULT_TIMEOUT,
     });
     return response.data.MediaContainer.Metadata?.[0];
@@ -159,7 +172,8 @@ export const updateStream = async (
         `${serverUrl}/library/parts/${partId}?${param}=${streamId}&allParts=1`,
         {},
         {
-            headers: getPmsHeaders(clientIdentifier, token),
+            params: getPmsParams(clientIdentifier, token),
+            headers: getPmsHeaders(),
             timeout: DEFAULT_TIMEOUT,
         }
     );


### PR DESCRIPTION
- Updated "use local address" to "prefer local address", to try to get around exclusively trying to use Docker network addresses
- Removed headers from local plex server queries in favour of URL parameters
  - This should resolve CORS issues with headers.
  - plex.tv api requests still remain as headers.