### PR TITLE
Docker build process improvements

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,25 +14,51 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      # Setup QEMU and Buildx for multi-platform image build
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       # Log in to Docker Hub
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # Build the Docker image with both the tag and latest
-      - name: Build Docker Image
-        run: |
-          docker build -t ${{ secrets.DOCKER_USERNAME }}/pasta:${{ github.event.release.tag_name }} .
-          docker tag ${{ secrets.DOCKER_USERNAME }}/pasta:${{ github.event.release.tag_name }} ${{ secrets.DOCKER_USERNAME }}/pasta:latest
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Push the Docker image with the release tag
-      - name: Push Docker Image with Release Tag
-        run: |
-          docker push ${{ secrets.DOCKER_USERNAME }}/pasta:${{ github.event.release.tag_name }}
-
-      # Push the Docker image as latest
-      - name: Push Docker Image as Latest
-        run: |
-          docker push ${{ secrets.DOCKER_USERNAME }}/pasta:latest
+      # Pull data automatically for tag and label info
+      -
+        name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          flavor: |
+            latest=auto
+          images: |
+            ${{ secrets.DOCKER_USERNAME }}/pasta
+            ghcr.io/${{ github.actor }}/pasta
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+      
+      # Build the Docker image with tags from metadata stage
+      -
+        name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          platforms: linux/amd64,linux/arm64
+          # Push if not pull requeste
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,9 @@ on:
     types:
       - published
 
+permissions:
+  packages: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Pull data automatically for tag and label info
@@ -50,7 +50,7 @@ jobs:
             latest=auto
           images: |
             ${{ secrets.DOCKER_USERNAME }}/pasta
-            ghcr.io/${{ github.actor }}/pasta
+            ghcr.io/${{ github.repository_owner }}/pasta
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
@@ -61,7 +61,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
-          # Push if not pull requeste
+          # Push if not pull requested
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- Add switch to official docker actions
  - Docker metadata action will automatically pull correct version information to create a rolling major release tag (i.e. cglatot/pasta:2)
- Setup multi-arch support for other platforms
  - Add ARM64 builds
- Add GHCR support

Example release
GH Action: https://github.com/adamus1red/pasta/actions/runs/28748247080
Docker Hub: https://hub.docker.com/r/adamus1red/pasta/tags
GHCR Container: https://github.com/adamus1red/pasta/pkgs/container/pasta